### PR TITLE
Remove unneeded port mappings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,7 @@ services:
       - "EUREKA_URI=http://jws-discovery:8761/"
       - "CONFIG_SERVER_URI=http://jws-config:8888/" 
     ports:
-      - "8070:8080"
+      - "8080:8080"
     restart: unless-stopped
     volumes:
       - "logdata:/opt/chemaxon/jws/logs"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,6 @@ services:
     environment: 
       - "EUREKA_URI=http://jws-discovery:8761/"
       - "CONFIG_SERVER_URI=http://jws-config:8888/"
-    ports:
-      - "8888:8888"
     restart: unless-stopped
     volumes:
       - "logdata:/opt/chemaxon/jws/logs"
@@ -34,8 +32,6 @@ services:
     environment: 
       - "EUREKA_URI=http://jws-discovery:8761/"
       - "CONFIG_SERVER_URI=http://jws-config:8888/"
-    ports:
-      - "8761:8761"
     restart: unless-stopped
     volumes:
       - "logdata:/opt/chemaxon/jws/logs"
@@ -46,8 +42,6 @@ services:
     environment: 
       - "EUREKA_URI=http://jws-discovery:8761/"
       - "CONFIG_SERVER_URI=http://jws-config:8888/" 
-    ports:
-      - "8084:8064"
     restart: unless-stopped
     volumes:
       - "logdata:/opt/chemaxon/jws/logs"
@@ -59,8 +53,6 @@ services:
     environment: 
       - "EUREKA_URI=http://jws-discovery:8761/"
       - "CONFIG_SERVER_URI=http://jws-config:8888/" 
-    ports:
-      - "8082:8062"
     restart: unless-stopped
     volumes:
       - "logdata:/opt/chemaxon/jws/logs"
@@ -73,8 +65,6 @@ services:
     environment: 
       - "EUREKA_URI=http://jws-discovery:8761/"
       - "CONFIG_SERVER_URI=http://jws-config:8888/" 
-    ports:
-      - "8081:8061"
     restart: unless-stopped
     volumes:
       - "logdata:/opt/chemaxon/jws/logs"
@@ -86,8 +76,6 @@ services:
     environment: 
       - "EUREKA_URI=http://jws-discovery:8761/"
       - "CONFIG_SERVER_URI=http://jws-config:8888/" 
-    ports:
-      - "8083:8063"
     restart: unless-stopped
     volumes:
       - "logdata:/opt/chemaxon/jws/logs"
@@ -99,8 +87,6 @@ services:
     environment: 
       - "EUREKA_URI=http://jws-discovery:8761/"
       - "CONFIG_SERVER_URI=http://jws-config:8888/" 
-    ports:
-      - "8085:8065"
     restart: unless-stopped
     volumes:
       - "logdata:/opt/chemaxon/jws/logs"
@@ -113,13 +99,13 @@ services:
       - "EUREKA_URI=http://jws-discovery:8761/"
       - "CONFIG_SERVER_URI=http://jws-config:8888/" 
     ports:
-      - "8080:8080"
+      - "8070:8080"
     restart: unless-stopped
     volumes:
       - "logdata:/opt/chemaxon/jws/logs"
     
 volumes:
-   logdata:
-   dbdata:
-   license:
-   config:
+  logdata:
+  dbdata:
+  license:
+  config:


### PR DESCRIPTION
In the presence of a gateway service, payload services don't need port-mappings,
which only "pollute" an otherwise crowded port-range (crowded especially in
a test environment).