### PR TITLE
Revert "Use a widely adopted, OS distro independent OpenJDK distro"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM adoptopenjdk/openjdk8
+FROM openjdk:8u181-jre-stretch
 
 ADD jws_unix_19.15.tar.gz /opt/chemaxon/
 COPY license.cxl /opt/chemaxon/jws/license/license.cxl


### PR DESCRIPTION
Reverts ChemAxon/jchem-microservices-docker-example#3

adoptopenjdk is not configured properly